### PR TITLE
fix: reorg issue

### DIFF
--- a/src/pages/deployment/index.page.tsx
+++ b/src/pages/deployment/index.page.tsx
@@ -68,7 +68,7 @@ const defaultRollupConfig: RollupConfig = {
   genesisBlockNum: 0,
   sequencerInboxMaxTimeVariation: {
     delayBlocks: 5760,
-    futureBlocks: 12,
+    futureBlocks: 48,
     delaySeconds: 86400,
     futureSeconds: 3600,
   },


### PR DESCRIPTION
not sure if we should bump the futureBlocks a bit more to account for the block.number update delay from l1->l2