### PR TITLE
adding new fields to node config

### DIFF
--- a/src/types/rollupConfigDataType.ts
+++ b/src/types/rollupConfigDataType.ts
@@ -32,6 +32,7 @@ export type RollupConfigData = {
   'node': {
     'forwarding-target': string;
     'sequencer': {
+      "max-tx-data-size": number;
       'enable': boolean;
       'dangerous': {
         'no-coordinator': boolean;
@@ -42,6 +43,7 @@ export type RollupConfigData = {
       enable: boolean;
     };
     'batch-poster': {
+      "max-size": number;
       'enable': boolean;
       'parent-chain-wallet': {
         'private-key': string;

--- a/src/utils/deployRollup.ts
+++ b/src/utils/deployRollup.ts
@@ -128,6 +128,7 @@ export async function deployRollup({
     'node': {
       'forwarding-target': '',
       'sequencer': {
+        'max-tx-data-size': 85000,
         'enable': true,
         'dangerous': {
           'no-coordinator': true,
@@ -138,6 +139,7 @@ export async function deployRollup({
         enable: true,
       },
       'batch-poster': {
+        'max-size': 90000,
         'enable': true,
         'parent-chain-wallet': {
           'private-key': '',


### PR DESCRIPTION
We'll want to lower the max transaction and batch size for L3s because the L2 has a lower max tx size than L1 (as it needs to to fit in the other batch metadata). In this PR we are setting MaxBatchSize to 90,000 and MaxTxDataSize to 85,000
