### PR TITLE
feat: move deployment summary to download step

### DIFF
--- a/src/components/Download.tsx
+++ b/src/components/Download.tsx
@@ -1,40 +1,47 @@
 import { useConfigDownloads } from '@/hooks/useConfigDownloads';
 import { CodeComponent } from './CodeComponent';
 import { StepTitle } from './StepTitle';
+import { DeploymentSummary } from './DeploymentSummary';
 
 export function Download() {
   const { rollupConfigDownloadData, rollupConfigDisplayData, l3Config } = useConfigDownloads();
 
   return (
-    <>
-      <StepTitle>Download Config</StepTitle>
-      <p className="my-1">Configuration files are required to deploy locally.</p>
-      <div className="mx-0 my-2 grid grid-cols-2 gap-4">
-        <div>
-          <h4 className="font-bold">Rollup Config</h4>
-          {!rollupConfigDownloadData ? (
-            <div>No rollup data found.</div>
-          ) : (
-            <CodeComponent
-              fileName="nodeConfig.json"
-              dataToDownload={rollupConfigDownloadData}
-              dataToDisplay={rollupConfigDisplayData}
-            />
-          )}
-        </div>
-        <div>
-          <h4 className="font-bold">L3 Config</h4>
-          {!l3Config ? (
-            <div>No L3 configuration data found.</div>
-          ) : (
-            <CodeComponent
-              fileName="orbitSetupScriptConfig.json"
-              dataToDownload={l3Config}
-              dataToDisplay={l3Config}
-            />
-          )}
+    <div className="mx-0 my-2 grid grid-cols-2 gap-4">
+      <div>
+        <StepTitle>Download Config</StepTitle>
+        <p className="my-1">Configuration files are required to deploy locally.</p>
+        <div className="mx-0 my-2">
+          <div>
+            <h4 className="font-bold">Rollup Config</h4>
+            {!rollupConfigDownloadData ? (
+              <div>No rollup data found.</div>
+            ) : (
+              <CodeComponent
+                fileName="nodeConfig.json"
+                dataToDownload={rollupConfigDownloadData}
+                dataToDisplay={rollupConfigDisplayData}
+              />
+            )}
+          </div>
+          <div>
+            <h4 className="font-bold">L3 Config</h4>
+            {!l3Config ? (
+              <div>No L3 configuration data found.</div>
+            ) : (
+              <CodeComponent
+                fileName="orbitSetupScriptConfig.json"
+                dataToDownload={l3Config}
+                dataToDisplay={l3Config}
+              />
+            )}
+          </div>
         </div>
       </div>
-    </>
+      <div>
+        <StepTitle>Deployment Summary</StepTitle>
+        <DeploymentSummary />
+      </div>
+    </div>
   );
 }

--- a/src/components/KeysetForm.tsx
+++ b/src/components/KeysetForm.tsx
@@ -44,7 +44,7 @@ export const KeysetForm = () => {
   };
 
   return (
-    <div className="mx-0 grid grid-cols-2 gap-4">
+    <>
       <div className="flex flex-col gap-4">
         <div className="flex items-baseline gap-2">
           <StepTitle>Configure Keyset</StepTitle>
@@ -67,10 +67,6 @@ export const KeysetForm = () => {
         </div>
         <form onSubmit={handleSubmit} className="flex flex-col gap-4" ref={keysetFormRef}></form>
       </div>
-      <div>
-        <StepTitle>Deployment Summary</StepTitle>
-        <DeploymentSummary />
-      </div>
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
Shows the deployment summary on the Download step so both Rollup and Anytrust users can see the summary

closes #54 

## new Download step
<img width="1278" alt="Screen Shot 2023-09-13 at 7 25 48 AM" src="https://github.com/OffchainLabs/orbit-deployment-ui/assets/4741454/1c177ba1-1faa-46f7-a874-b742e0bf82ce">

## new Keyset step
<img width="1337" alt="Screen Shot 2023-09-13 at 7 34 15 AM" src="https://github.com/OffchainLabs/orbit-deployment-ui/assets/4741454/3ca5ae22-929b-4e06-8435-d50777f5933f">
